### PR TITLE
Refactor offline sensor into binary sensor type

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,10 @@ uart:
   baud_rate: 9600
 
 fourheat:
-  offline_sensor:
-    name: Stove offline
 ```
 
 ### Configuration variables:
 
-- **offline_sensor** (*Optional*): Used for indicating if the 4Heat controller is offline. All options from [Binary Sensor](https://esphome.io/components/binary_sensor/#base-binary-sensor-configuration).
 - **update_interval** (*Optional*, [Time](https://esphome.io/guides/configuration-types#config-time)): The interval to query all sensors. Defaults to 15s.
 
 
@@ -152,17 +149,28 @@ Requires FourHeat Component to be configured.
 
 ```yaml
 binary_sensor:
+  # Datapoint binary sensor
   - platform: fourheat
     name: My Binary Sensor
     datapoint: J30000
     query_datapoint: I30000
     parser: return data[data.size() - 1] != '0';
+
+  # Offline sensor
+  - platform: fourheat
+    name: Module Offline Sensor
+    type: module_offline
 ```
 
 ### Configuration variables:
 
 - **id** (*Optional*, [ID](https://esphome.io/guides/configuration-types#config-id)): Manually specify the ID used for code generation.
 - **name** (**Required**, string): The name of the binary sensor.
+- **type** (*Optional*, enum): `binary_sensor` type. Defaults to `datapoint`.
+  - `datapoint`: datapoint sensor.
+  - `module_offline`: indicates if the 4Heat controller is offline.
+
+### Datapoint
 - **datapoint** (**Required**, [datapoint](#custom-variable-types)): The datapoint id of the binary sensor.
 - **query_datapoint** (*Optional*, [datapoint](#custom-variable-types)): The query datapoint id of the binary sensor. If not specified, uses `datapoint` with prefix letter decremented by one.
 - **parser** (*Optional*, [lambda](https://esphome.io/guides/automations#config-lambda)): Lambda for custom data parsing logic. Provides `std::vector<uint8_t> data` and must return `bool`.

--- a/components/fourheat/__init__.py
+++ b/components/fourheat/__init__.py
@@ -1,13 +1,8 @@
 from typing import Generator
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor as binary_sensor_
 from esphome.components import uart
-from esphome.const import (
-    CONF_ID,
-    DEVICE_CLASS_PROBLEM,
-    ENTITY_CATEGORY_DIAGNOSTIC,
-)
+from esphome.const import CONF_ID
 from esphome.core import Lambda
 from esphome.cpp_generator import LambdaExpression, SafeExpType
 
@@ -19,7 +14,6 @@ FourHeat = fourheat_ns.class_("FourHeat", cg.PollingComponent, uart.UARTDevice)
 CONF_FOURHEAT_ID = "fourheat_id"
 
 CONF_DATAPOINT = "datapoint"
-CONF_OFFLINE_SENSOR = "offline_sensor"
 CONF_PARSER = "parser"
 CONF_QUERY_DATAPOINT = "query_datapoint"
 
@@ -27,10 +21,6 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(FourHeat),
-            cv.Optional(CONF_OFFLINE_SENSOR): binary_sensor_.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            ),
         }
     )
     .extend(cv.polling_component_schema("15s"))
@@ -41,10 +31,6 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-
-    if CONF_OFFLINE_SENSOR in config:
-        sens = await binary_sensor_.new_binary_sensor(config[CONF_OFFLINE_SENSOR])
-        cg.add(var.set_module_offline_sensor(sens))
 
 async def get_parser_expression(value: Lambda, return_type: SafeExpType) -> Generator[LambdaExpression, None, None]:
     return await cg.process_lambda(

--- a/components/fourheat/binary_sensor/__init__.py
+++ b/components/fourheat/binary_sensor/__init__.py
@@ -1,6 +1,11 @@
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 import esphome.codegen as cg
+from esphome.const import (
+    CONF_TYPE,
+    DEVICE_CLASS_PROBLEM,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
 
 from .. import fourheat_config_validation as fhcv
 from .. import (
@@ -17,33 +22,50 @@ DEPENDENCIES = ["fourheat"]
 
 FourHeatBinarySensor = fourheat_ns.class_("FourHeatBinarySensor", binary_sensor.BinarySensor, cg.Component)
 
-CONFIG_SCHEMA = (
-    binary_sensor.binary_sensor_schema(FourHeatBinarySensor)
-    .extend(
-        {
-            cv.GenerateID(CONF_FOURHEAT_ID): cv.use_id(FourHeat),
-            cv.Required(CONF_DATAPOINT): fhcv.datapoint,
-            cv.Optional(CONF_QUERY_DATAPOINT): fhcv.datapoint,
+CONF_OFFLINE_SENSOR = "offline_sensor"
 
-            cv.Optional(CONF_PARSER): cv.returning_lambda,
-        }
-    )
-    .extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "datapoint": binary_sensor.binary_sensor_schema(FourHeatBinarySensor).extend(
+            {
+                cv.GenerateID(CONF_FOURHEAT_ID): cv.use_id(FourHeat),
+                cv.Required(CONF_DATAPOINT): fhcv.datapoint,
+                cv.Optional(CONF_QUERY_DATAPOINT): fhcv.datapoint,
+
+                cv.Optional(CONF_PARSER): cv.returning_lambda,
+            }
+        )
+        .extend(cv.COMPONENT_SCHEMA),
+
+        "offline": binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_PROBLEM,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    },
+    lower=True,
+    key=CONF_TYPE,
+    default_type="datapoint",
 )
 
-
 async def to_code(config):
-    var = await binary_sensor.new_binary_sensor(config)
-    await cg.register_component(var, config)
-
     parent = await cg.get_variable(config[CONF_FOURHEAT_ID])
-    cg.add(var.set_fourheat_parent(parent))
 
-    cg.add(var.set_datapoint_id(config[CONF_DATAPOINT]))
+    # Offline sensor
+    if config[CONF_TYPE] == "offline":
+        sens = await binary_sensor.new_binary_sensor(config[CONF_OFFLINE_SENSOR])
+        cg.add(parent.set_module_offline_sensor(sens))
+    # Datapoint sensor
+    else:
+        var = await binary_sensor.new_binary_sensor(config)
+        await cg.register_component(var, config)
 
-    if CONF_QUERY_DATAPOINT in config:
-        cg.add(var.set_query_datapoint_id(config[CONF_QUERY_DATAPOINT]))
+        cg.add(var.set_fourheat_parent(parent))
 
-    if CONF_PARSER in config:
-        lambda_ = await get_parser_expression(config[CONF_PARSER], bool)
-        cg.add(var.set_parser(lambda_))
+        cg.add(var.set_datapoint_id(config[CONF_DATAPOINT]))
+
+        if CONF_QUERY_DATAPOINT in config:
+            cg.add(var.set_query_datapoint_id(config[CONF_QUERY_DATAPOINT]))
+
+        if CONF_PARSER in config:
+            lambda_ = await get_parser_expression(config[CONF_PARSER], bool)
+            cg.add(var.set_parser(lambda_))

--- a/components/fourheat/binary_sensor/__init__.py
+++ b/components/fourheat/binary_sensor/__init__.py
@@ -22,11 +22,12 @@ DEPENDENCIES = ["fourheat"]
 
 FourHeatBinarySensor = fourheat_ns.class_("FourHeatBinarySensor", binary_sensor.BinarySensor, cg.Component)
 
-CONF_OFFLINE_SENSOR = "offline_sensor"
+CONF_TYPE_DATAPOINT = "datapoint"
+CONF_TYPE_OFFLINE = "offline"
 
 CONFIG_SCHEMA = cv.typed_schema(
     {
-        "datapoint": binary_sensor.binary_sensor_schema(FourHeatBinarySensor).extend(
+        CONF_TYPE_DATAPOINT: binary_sensor.binary_sensor_schema(FourHeatBinarySensor).extend(
             {
                 cv.GenerateID(CONF_FOURHEAT_ID): cv.use_id(FourHeat),
                 cv.Required(CONF_DATAPOINT): fhcv.datapoint,
@@ -37,10 +38,17 @@ CONFIG_SCHEMA = cv.typed_schema(
         )
         .extend(cv.COMPONENT_SCHEMA),
 
-        "offline": binary_sensor.binary_sensor_schema(
+        CONF_TYPE_OFFLINE: binary_sensor.binary_sensor_schema(
+            FourHeatBinarySensor,
             device_class=DEVICE_CLASS_PROBLEM,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
+        )
+        .extend(
+            {
+                cv.GenerateID(CONF_FOURHEAT_ID): cv.use_id(FourHeat),
+            }
+        )
+        .extend(cv.COMPONENT_SCHEMA),
     },
     lower=True,
     key=CONF_TYPE,
@@ -51,8 +59,8 @@ async def to_code(config):
     parent = await cg.get_variable(config[CONF_FOURHEAT_ID])
 
     # Offline sensor
-    if config[CONF_TYPE] == "offline":
-        sens = await binary_sensor.new_binary_sensor(config[CONF_OFFLINE_SENSOR])
+    if config[CONF_TYPE] == CONF_TYPE_OFFLINE:
+        sens = await binary_sensor.new_binary_sensor(config)
         cg.add(parent.set_module_offline_sensor(sens))
     # Datapoint sensor
     else:

--- a/components/fourheat/binary_sensor/__init__.py
+++ b/components/fourheat/binary_sensor/__init__.py
@@ -23,7 +23,7 @@ DEPENDENCIES = ["fourheat"]
 FourHeatBinarySensor = fourheat_ns.class_("FourHeatBinarySensor", binary_sensor.BinarySensor, cg.Component)
 
 CONF_TYPE_DATAPOINT = "datapoint"
-CONF_TYPE_OFFLINE = "offline"
+CONF_TYPE_OFFLINE = "module_offline"
 
 CONFIG_SCHEMA = cv.typed_schema(
     {
@@ -52,7 +52,7 @@ CONFIG_SCHEMA = cv.typed_schema(
     },
     lower=True,
     key=CONF_TYPE,
-    default_type="datapoint",
+    default_type=CONF_TYPE_DATAPOINT,
 )
 
 async def to_code(config):

--- a/components/fourheat/fourheat.cpp
+++ b/components/fourheat/fourheat.cpp
@@ -48,9 +48,11 @@ void FourHeat::dump_config() {
   ESP_LOGCONFIG(TAG, "4Heat:");
 }
 
+#ifdef USE_BINARY_SENSOR
 void FourHeat::set_module_offline_sensor(binary_sensor::BinarySensor *module_offline_sensor) {
   this->module_offline_sensor_ = module_offline_sensor;
 }
+#endif
 
 void FourHeat::register_query(const std::string &id) {
   std::vector<uint8_t> data;
@@ -249,9 +251,11 @@ bool FourHeat::create_message_(const std::string &id, const std::vector<uint8_t>
 void FourHeat::set_module_offline_(bool offline) {
   this->module_offline_ = offline;
 
+#ifdef USE_BINARY_SENSOR
   if (this->module_offline_sensor_ != nullptr) {
     this->module_offline_sensor_->publish_state(offline);
   }
+#endif
 }
 
 }  // namespace fourheat

--- a/components/fourheat/fourheat.h
+++ b/components/fourheat/fourheat.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+
+#ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
 #include "esphome/components/uart/uart.h"
 
 #include <queue>
@@ -22,7 +27,9 @@ class FourHeat : public PollingComponent, public uart::UARTDevice {
   void update() override;
   void dump_config() override;
 
+#ifdef USE_BINARY_SENSOR
   void set_module_offline_sensor(binary_sensor::BinarySensor *module_offline_sensor);
+#endif
   void register_query(const std::string &id);
   void register_listener(const std::string &id, const std::function<void(const std::vector<uint8_t>)> &func);
 
@@ -33,7 +40,9 @@ class FourHeat : public PollingComponent, public uart::UARTDevice {
   void send_bool_value(const std::string &id, bool value);
 
  protected:
+#ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *module_offline_sensor_{nullptr};
+#endif
 
   uint32_t last_rx_char_timestamp_{0};
   uint32_t last_tx_message_timestamp_{0};

--- a/example.yaml
+++ b/example.yaml
@@ -11,9 +11,6 @@ uart:
   baud_rate: 9600
 
 fourheat:
-  offline_sensor:
-    id: stove_offline
-    name: Stove offline
 
 switch:
   - id: state_switch
@@ -101,6 +98,11 @@ select:
       7: "Auto"
 
 binary_sensor:
+  - id: stove_offline
+    name: Stove offline
+    platform: fourheat
+    type: module_offline
+
   - id: room_thermostat_state
     name: Room thermostat state
     platform: fourheat


### PR DESCRIPTION
Moves offline sensor from `fourheat` component into `binary_sensor` type.

Before:
```yaml
fourheat:
  offline_sensor:
    name: Stove offline
```

After:
```yaml
fourheat:

binary_sensor:
  - platform: fourheat
    name: Stove offline
    type: module_offline
```

The reason is, ESPHome only includes `binary_sensor.h` if the top level `binary_sensor` exists, so the compilation fails, if you only use offline sensor and no other binary sensors.

Fixes #2 