### PR TITLE
Replace std::optional with esphome::optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Someone [here](https://www.solarweb.net/forosolar/usuarios-biomasa/56621-comunic
 
 ### Custom parsers
 
-Every component supports custom data parser. You will get `std::vector<uint8_t> data` to work with, with only the data part of the received message (without the datapoint ID), and you must return a value of the correct type. If you don't want to return anything (you receive data you don't expect), return `{}` - empty `std::optional`.
+Every component supports custom data parser. You will get `std::vector<uint8_t> data` to work with, with only the data part of the received message (without the datapoint ID), and you must return a value of the correct type. If you don't want to return anything (you receive data you don't expect), return `{}` - empty `esphome::optional`.
 
 If your parser doesn't return any value, the default one is then **not** called.
 

--- a/components/fourheat/__init__.py
+++ b/components/fourheat/__init__.py
@@ -5,6 +5,7 @@ from esphome.components import uart
 from esphome.const import CONF_ID
 from esphome.core import Lambda
 from esphome.cpp_generator import LambdaExpression, SafeExpType
+from esphome.cpp_types import optional
 
 DEPENDENCIES = ["uart"]
 
@@ -41,5 +42,5 @@ async def get_parser_expression(value: Lambda, return_type: SafeExpType) -> Gene
                 "data",
             ),
         ],
-        return_type=cg.std_ns.class_("optional").template(return_type)
+        return_type=cg.optional.template(return_type)
     )

--- a/components/fourheat/binary_sensor/fourheat_binary_sensor.h
+++ b/components/fourheat/binary_sensor/fourheat_binary_sensor.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
-
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -24,9 +23,9 @@ class FourHeatBinarySensor : public binary_sensor::BinarySensor, public Componen
  protected:
   FourHeat *parent_;
   std::string datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
 
-  std::optional<parser_t<bool>> parser_;
+  esphome::optional<parser_t<bool>> parser_;
 
   void handle_data_(const std::vector<uint8_t> &data);
 };

--- a/components/fourheat/climate/fourheat_climate.h
+++ b/components/fourheat/climate/fourheat_climate.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
-
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -38,18 +37,18 @@ class FourHeatClimate : public climate::Climate, public Component {
   std::string datapoint_id_;
   std::string current_temperature_datapoint_id_;
   std::string target_temperature_datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
-  std::optional<std::string> query_current_temperature_datapoint_id_;
-  std::optional<std::string> query_target_temperature_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_current_temperature_datapoint_id_;
+  esphome::optional<std::string> query_target_temperature_datapoint_id_;
 
-  std::optional<parser_t<bool>> parser_;
-  std::optional<parser_t<int>> current_temperature_parser_;
-  std::optional<parser_t<int>> target_temperature_parser_;
+  esphome::optional<parser_t<bool>> parser_;
+  esphome::optional<parser_t<int>> current_temperature_parser_;
+  esphome::optional<parser_t<int>> target_temperature_parser_;
 
-  std::optional<std::string> on_datapoint_id_;
-  std::optional<std::string> off_datapoint_id_;
-  std::optional<std::string> on_data_;
-  std::optional<std::string> off_data_;
+  esphome::optional<std::string> on_datapoint_id_;
+  esphome::optional<std::string> off_datapoint_id_;
+  esphome::optional<std::string> on_data_;
+  esphome::optional<std::string> off_data_;
 
   void control(const climate::ClimateCall &call) override;
   climate::ClimateTraits traits() override;

--- a/components/fourheat/common.h
+++ b/components/fourheat/common.h
@@ -2,7 +2,8 @@
 
 #include <ctype.h>
 #include <functional>
-#include <optional>
+
+#include "esphome/core/optional.h"
 
 template<typename T>
-using parser_t = std::function<std::optional<T>(const std::vector<uint8_t> &)>;
+using parser_t = std::function<esphome::optional<T>(const std::vector<uint8_t> &)>;

--- a/components/fourheat/fourheat.h
+++ b/components/fourheat/fourheat.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <queue>
+
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 
@@ -8,8 +10,6 @@
 #endif
 
 #include "esphome/components/uart/uart.h"
-
-#include <queue>
 
 namespace esphome {
 namespace fourheat {

--- a/components/fourheat/helpers.cpp
+++ b/components/fourheat/helpers.cpp
@@ -34,7 +34,7 @@ bool parse_int(const std::vector<uint8_t> &data, int &value) {
   return true;
 }
 
-const std::string get_query_datapoint_id(const std::string &datapoint_id, const std::optional<std::string> &query_datapoint_id) {
+const std::string get_query_datapoint_id(const std::string &datapoint_id, const esphome::optional<std::string> &query_datapoint_id) {
   if (query_datapoint_id.has_value()) {
     return query_datapoint_id.value();
   }
@@ -46,7 +46,7 @@ const std::string get_query_datapoint_id(const std::string &datapoint_id, const 
 }
 
 template<>
-std::optional<bool> parse(const std::optional<parser_t<bool>> &parser, const std::vector<uint8_t> &data) {
+esphome::optional<bool> parse(const esphome::optional<parser_t<bool>> &parser, const std::vector<uint8_t> &data) {
   if (parser.has_value()) {
     return parser.value()(data);
   }
@@ -54,14 +54,14 @@ std::optional<bool> parse(const std::optional<parser_t<bool>> &parser, const std
   bool value;
 
   if (!parse_bool(data, value)) {
-    return std::nullopt;
+    return esphome::nullopt;
   }
 
   return value;
 }
 
 template<>
-std::optional<int> parse(const std::optional<parser_t<int>> &parser, const std::vector<uint8_t> &data) {
+esphome::optional<int> parse(const esphome::optional<parser_t<int>> &parser, const std::vector<uint8_t> &data) {
   if (parser.has_value()) {
     return parser.value()(data);
   }
@@ -69,7 +69,7 @@ std::optional<int> parse(const std::optional<parser_t<int>> &parser, const std::
   int value;
 
   if (!parse_int(data, value)) {
-    return std::nullopt;
+    return esphome::nullopt;
   }
 
   return value;

--- a/components/fourheat/helpers.h
+++ b/components/fourheat/helpers.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "common.h"
-
 #include <ctype.h>
 #include <functional>
-#include <optional>
 #include <stdint.h>
 #include <string>
 #include <vector>
+
+#include "common.h"
 
 namespace esphome {
 namespace fourheat {
@@ -15,10 +14,10 @@ namespace fourheat {
 bool parse_bool(const std::vector<uint8_t> &data, bool &value);
 bool parse_int(const std::vector<uint8_t> &data, int &value);
 
-const std::string get_query_datapoint_id(const std::string &datapoint_id, const std::optional<std::string> &query_datapoint_id);
+const std::string get_query_datapoint_id(const std::string &datapoint_id, const esphome::optional<std::string> &query_datapoint_id);
 
 template<typename T>
-std::optional<T> parse(const std::optional<parser_t<T>> &parser, const std::vector<uint8_t> &data);
+esphome::optional<T> parse(const esphome::optional<parser_t<T>> &parser, const std::vector<uint8_t> &data);
 
 }  // namespace fourheat
 }  // namespace esphome

--- a/components/fourheat/number/fourheat_number.h
+++ b/components/fourheat/number/fourheat_number.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
 #include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
 #include "esphome/components/number/number.h"
-
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -24,9 +23,9 @@ class FourHeatNumber : public number::Number, public Component {
  protected:
   FourHeat *parent_;
   std::string datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
 
-  std::optional<parser_t<int>> parser_;
+  esphome::optional<parser_t<int>> parser_;
 
   void control(float value) override;
   

--- a/components/fourheat/select/fourheat_select.h
+++ b/components/fourheat/select/fourheat_select.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <map>
+#include <optional>
+
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
 #include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
 #include "esphome/components/select/select.h"
-
-#include <map>
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -29,9 +30,9 @@ class FourHeatSelect : public select::Select, public Component {
   FourHeat *parent_;
   bool optimistic_{false};
   std::string datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
 
-  std::optional<parser_t<int>> parser_;
+  esphome::optional<parser_t<int>> parser_;
 
   std::map<int, std::string> options_;
 

--- a/components/fourheat/sensor/fourheat_sensor.h
+++ b/components/fourheat/sensor/fourheat_sensor.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
+#include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
 #include "esphome/components/sensor/sensor.h"
-
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -23,9 +23,9 @@ class FourHeatSensor : public sensor::Sensor, public Component {
  protected:
   FourHeat *parent_;
   std::string datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
 
-  std::optional<parser_t<int>> parser_;
+  esphome::optional<parser_t<int>> parser_;
 
   void handle_data_(const std::vector<uint8_t> &data);
 };

--- a/components/fourheat/switch/fourheat_switch.h
+++ b/components/fourheat/switch/fourheat_switch.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
+#include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
 #include "esphome/components/switch/switch.h"
-
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -28,9 +28,9 @@ class FourHeatSwitch : public switch_::Switch, public Component {
  protected:
   FourHeat *parent_;
   std::string datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
 
-  std::optional<parser_t<bool>> parser_;
+  esphome::optional<parser_t<bool>> parser_;
 
   optional<std::string> on_datapoint_id_;
   optional<std::string> off_datapoint_id_;

--- a/components/fourheat/text_sensor/fourheat_text_sensor.h
+++ b/components/fourheat/text_sensor/fourheat_text_sensor.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/optional.h"
+#include "esphome/components/fourheat/common.h"
 #include "esphome/components/fourheat/fourheat.h"
 #include "esphome/components/text_sensor/text_sensor.h"
-
-#include <optional>
 
 namespace esphome {
 namespace fourheat {
@@ -25,9 +25,9 @@ class FourHeatTextSensor : public text_sensor::TextSensor, public Component {
  protected:
   FourHeat *parent_;
   std::string datapoint_id_;
-  std::optional<std::string> query_datapoint_id_;
+  esphome::optional<std::string> query_datapoint_id_;
 
-  std::optional<parser_t<int>> parser_;
+  esphome::optional<parser_t<int>> parser_;
 
   std::map<int, std::string> options_;
 


### PR DESCRIPTION
Apparently Arduino framework uses older C++ version that doesn't have `std::optional` yet.
I've noticed that ESPHome comes with its own `esphome::optional` implementation, so I switched to that one.

fixes #6