### PR TITLE
refactor: use std::move for parameters in setters

### DIFF
--- a/components/fourheat/binary_sensor/fourheat_binary_sensor.cpp
+++ b/components/fourheat/binary_sensor/fourheat_binary_sensor.cpp
@@ -23,8 +23,8 @@ void FourHeatBinarySensor::dump_config() {
 }
 
 void FourHeatBinarySensor::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
-void FourHeatBinarySensor::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatBinarySensor::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
+void FourHeatBinarySensor::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatBinarySensor::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatBinarySensor::set_parser(const parser_t<bool> &parser) { this->parser_ = parser; }
 

--- a/components/fourheat/binary_sensor/fourheat_binary_sensor.h
+++ b/components/fourheat/binary_sensor/fourheat_binary_sensor.h
@@ -15,8 +15,8 @@ class FourHeatBinarySensor : public binary_sensor::BinarySensor, public Componen
   void dump_config() override;
   
   void set_fourheat_parent(FourHeat *parent);
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<bool> &parser);
 

--- a/components/fourheat/button/fourheat_button.cpp
+++ b/components/fourheat/button/fourheat_button.cpp
@@ -13,9 +13,9 @@ void FourHeatButton::dump_config() {
 }
 
 void FourHeatButton::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
-void FourHeatButton::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
+void FourHeatButton::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
 
-void FourHeatButton::set_press_data(const std::string press_data) { this->press_data_ = press_data; }
+void FourHeatButton::set_press_data(std::string press_data) { this->press_data_ = std::move(press_data); }
 
 void FourHeatButton::press_action() {
   ESP_LOGV(TAG, "Button %s pressed", this->datapoint_id_.c_str());

--- a/components/fourheat/button/fourheat_button.h
+++ b/components/fourheat/button/fourheat_button.h
@@ -12,9 +12,9 @@ class FourHeatButton : public button::Button, public Component {
   void dump_config() override;
   
   void set_fourheat_parent(FourHeat *parent);
-  void set_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
 
-  void set_press_data(const std::string press_data);
+  void set_press_data(std::string press_data);
 
  protected:
   FourHeat *parent_;

--- a/components/fourheat/climate/fourheat_climate.cpp
+++ b/components/fourheat/climate/fourheat_climate.cpp
@@ -37,21 +37,21 @@ void FourHeatClimate::dump_config() {
 
 void FourHeatClimate::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
 
-void FourHeatClimate::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_current_temperature_datapoint_id(const std::string datapoint_id) { this->current_temperature_datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_target_temperature_datapoint_id(const std::string datapoint_id) { this->target_temperature_datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_query_current_temperature_datapoint_id(const std::string datapoint_id) { this->query_current_temperature_datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_query_target_temperature_datapoint_id(const std::string datapoint_id) { this->query_target_temperature_datapoint_id_ = datapoint_id; }
+void FourHeatClimate::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_current_temperature_datapoint_id(std::string datapoint_id) { this->current_temperature_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_target_temperature_datapoint_id(std::string datapoint_id) { this->target_temperature_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_query_current_temperature_datapoint_id(std::string datapoint_id) { this->query_current_temperature_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_query_target_temperature_datapoint_id(std::string datapoint_id) { this->query_target_temperature_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatClimate::set_parser(const parser_t<bool> &parser) { this->parser_ = parser; }
 void FourHeatClimate::set_current_temperature_parser(const parser_t<int> &parser) { this->current_temperature_parser_ = parser; }
 void FourHeatClimate::set_target_temperature_parser(const parser_t<int> &parser) { this->target_temperature_parser_ = parser; }
 
-void FourHeatClimate::set_on_datapoint_id(const std::string datapoint_id) { this->on_datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_off_datapoint_id(const std::string datapoint_id) { this->off_datapoint_id_ = datapoint_id; }
-void FourHeatClimate::set_on_data(const std::string data) { this->on_data_ = data; }
-void FourHeatClimate::set_off_data(const std::string data) { this->off_data_ = data; }
+void FourHeatClimate::set_on_datapoint_id(std::string datapoint_id) { this->on_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_off_datapoint_id(std::string datapoint_id) { this->off_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatClimate::set_on_data(std::string data) { this->on_data_ = std::move(data); }
+void FourHeatClimate::set_off_data(std::string data) { this->off_data_ = std::move(data); }
 
 void FourHeatClimate::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()) {

--- a/components/fourheat/climate/fourheat_climate.h
+++ b/components/fourheat/climate/fourheat_climate.h
@@ -16,21 +16,21 @@ class FourHeatClimate : public climate::Climate, public Component {
 
   void set_fourheat_parent(FourHeat *parent);
 
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_current_temperature_datapoint_id(const std::string datapoint_id);
-  void set_target_temperature_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
-  void set_query_current_temperature_datapoint_id(const std::string datapoint_id);
-  void set_query_target_temperature_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_current_temperature_datapoint_id(std::string datapoint_id);
+  void set_target_temperature_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
+  void set_query_current_temperature_datapoint_id(std::string datapoint_id);
+  void set_query_target_temperature_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<bool> &parser);
   void set_current_temperature_parser(const parser_t<int> &parser);
   void set_target_temperature_parser(const parser_t<int> &parser);
   
-  void set_on_datapoint_id(const std::string datapoint_id);
-  void set_off_datapoint_id(const std::string datapoint_id);
-  void set_on_data(const std::string data);
-  void set_off_data(const std::string data);
+  void set_on_datapoint_id(std::string datapoint_id);
+  void set_off_datapoint_id(std::string datapoint_id);
+  void set_on_data(std::string data);
+  void set_off_data(std::string data);
 
  protected:
   FourHeat *parent_;

--- a/components/fourheat/number/fourheat_number.cpp
+++ b/components/fourheat/number/fourheat_number.cpp
@@ -27,8 +27,8 @@ void FourHeatNumber::dump_config() {
 }
 
 void FourHeatNumber::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
-void FourHeatNumber::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatNumber::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
+void FourHeatNumber::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatNumber::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatNumber::set_parser(const parser_t<int> &parser) { this->parser_ = parser; }
 

--- a/components/fourheat/number/fourheat_number.h
+++ b/components/fourheat/number/fourheat_number.h
@@ -15,8 +15,8 @@ class FourHeatNumber : public number::Number, public Component {
   void dump_config() override;
   
   void set_fourheat_parent(FourHeat *parent);
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<int> &parser);
 

--- a/components/fourheat/select/fourheat_select.cpp
+++ b/components/fourheat/select/fourheat_select.cpp
@@ -32,12 +32,12 @@ void FourHeatSelect::dump_config() {
 
 void FourHeatSelect::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
 void FourHeatSelect::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-void FourHeatSelect::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatSelect::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
+void FourHeatSelect::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatSelect::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatSelect::set_parser(const parser_t<int> &parser) { this->parser_ = parser; }
 
-void FourHeatSelect::set_options(const std::map<int, std::string> options) { this->options_ = std::move(options); }
+void FourHeatSelect::set_options(std::map<int, std::string> options) { this->options_ = std::move(options); }
 
 void FourHeatSelect::control(const std::string &value) {
   auto it = std::find_if(this->options_.begin(), this->options_.end(), [&value](const std::pair<int, std::string> &p) {

--- a/components/fourheat/select/fourheat_select.h
+++ b/components/fourheat/select/fourheat_select.h
@@ -18,12 +18,12 @@ class FourHeatSelect : public select::Select, public Component {
 
   void set_fourheat_parent(FourHeat *parent);
   void set_optimistic(bool optimistic);
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<int> &parser);
   
-  void set_options(const std::map<int, std::string> options);
+  void set_options(std::map<int, std::string> options);
 
  protected:
   FourHeat *parent_;

--- a/components/fourheat/sensor/fourheat_sensor.cpp
+++ b/components/fourheat/sensor/fourheat_sensor.cpp
@@ -23,8 +23,8 @@ void FourHeatSensor::dump_config() {
 }
 
 void FourHeatSensor::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
-void FourHeatSensor::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatSensor::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
+void FourHeatSensor::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatSensor::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatSensor::set_parser(const parser_t<int> &parser) { this->parser_ = parser; }
 

--- a/components/fourheat/sensor/fourheat_sensor.h
+++ b/components/fourheat/sensor/fourheat_sensor.h
@@ -15,8 +15,8 @@ class FourHeatSensor : public sensor::Sensor, public Component {
   void dump_config() override;
   
   void set_fourheat_parent(FourHeat *parent);
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<int> &parser);
 

--- a/components/fourheat/switch/fourheat_switch.cpp
+++ b/components/fourheat/switch/fourheat_switch.cpp
@@ -27,15 +27,15 @@ void FourHeatSwitch::dump_config() {
 }
 
 void FourHeatSwitch::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
-void FourHeatSwitch::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatSwitch::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
+void FourHeatSwitch::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatSwitch::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatSwitch::set_parser(const parser_t<bool> &parser) { this->parser_ = parser; }
 
-void FourHeatSwitch::set_on_datapoint_id(const std::string datapoint_id) { this->on_datapoint_id_ = datapoint_id; }
-void FourHeatSwitch::set_off_datapoint_id(const std::string datapoint_id) { this->off_datapoint_id_ = datapoint_id; }
-void FourHeatSwitch::set_on_data(const std::string data) { this->on_data_ = data; }
-void FourHeatSwitch::set_off_data(const std::string data) { this->off_data_ = data; }
+void FourHeatSwitch::set_on_datapoint_id(std::string datapoint_id) { this->on_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatSwitch::set_off_datapoint_id(std::string datapoint_id) { this->off_datapoint_id_ = std::move(datapoint_id); }
+void FourHeatSwitch::set_on_data(std::string data) { this->on_data_ = std::move(data); }
+void FourHeatSwitch::set_off_data(std::string data) { this->off_data_ = std::move(data); }
 
 void FourHeatSwitch::write_state(bool state) {
   ESP_LOGV(TAG, "Setting switch %s: %s", this->datapoint_id_.c_str(), ONOFF(state));

--- a/components/fourheat/switch/fourheat_switch.h
+++ b/components/fourheat/switch/fourheat_switch.h
@@ -15,15 +15,15 @@ class FourHeatSwitch : public switch_::Switch, public Component {
   void dump_config() override;
 
   void set_fourheat_parent(FourHeat *parent);
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<bool> &parser);
 
-  void set_on_datapoint_id(const std::string datapoint_id);
-  void set_off_datapoint_id(const std::string datapoint_id);
-  void set_on_data(const std::string data);
-  void set_off_data(const std::string data);
+  void set_on_datapoint_id(std::string datapoint_id);
+  void set_off_datapoint_id(std::string datapoint_id);
+  void set_on_data(std::string data);
+  void set_off_data(std::string data);
 
  protected:
   FourHeat *parent_;

--- a/components/fourheat/text_sensor/fourheat_text_sensor.cpp
+++ b/components/fourheat/text_sensor/fourheat_text_sensor.cpp
@@ -23,12 +23,12 @@ void FourHeatTextSensor::dump_config() {
 }
 
 void FourHeatTextSensor::set_fourheat_parent(FourHeat *parent) { this->parent_ = parent; }
-void FourHeatTextSensor::set_datapoint_id(const std::string datapoint_id) { this->datapoint_id_ = datapoint_id; }
-void FourHeatTextSensor::set_query_datapoint_id(const std::string datapoint_id) { this->query_datapoint_id_ = datapoint_id; }
+void FourHeatTextSensor::set_datapoint_id(std::string datapoint_id) { this->datapoint_id_ = std::move(datapoint_id); }
+void FourHeatTextSensor::set_query_datapoint_id(std::string datapoint_id) { this->query_datapoint_id_ = std::move(datapoint_id); }
 
 void FourHeatTextSensor::set_parser(const parser_t<int> &parser) { this->parser_ = parser; }
 
-void FourHeatTextSensor::set_options(const std::map<int, std::string> options) { this->options_ = std::move(options); }
+void FourHeatTextSensor::set_options(std::map<int, std::string> options) { this->options_ = std::move(options); }
 
 void FourHeatTextSensor::handle_data_(const std::vector<uint8_t> &data) {
   auto parsed = parse<int>(this->parser_, data);

--- a/components/fourheat/text_sensor/fourheat_text_sensor.h
+++ b/components/fourheat/text_sensor/fourheat_text_sensor.h
@@ -17,12 +17,12 @@ class FourHeatTextSensor : public text_sensor::TextSensor, public Component {
   void dump_config() override;
 
   void set_fourheat_parent(FourHeat *parent);
-  void set_datapoint_id(const std::string datapoint_id);
-  void set_query_datapoint_id(const std::string datapoint_id);
+  void set_datapoint_id(std::string datapoint_id);
+  void set_query_datapoint_id(std::string datapoint_id);
 
   void set_parser(const parser_t<int> &parser);
 
-  void set_options(const std::map<int, std::string> options);
+  void set_options(std::map<int, std::string> options);
 
  protected:
   FourHeat *parent_;


### PR DESCRIPTION
Avoids unnecessary copy in component setters.